### PR TITLE
Moves `cd` command to .bashrc because .bash_profile was stomping .bashrc...

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -4,6 +4,6 @@ apt-get update -y
 # memcached and redis will be running on their standard ports.
 apt-get install -y curl git redis-server memcached libcurl3 libcurl3-gnutls libcurl4-openssl-dev
 
-if ! grep -lq  'cd /vagrant' /home/vagrant/.bash_profile ; then
-  echo "cd /vagrant" >> /home/vagrant/.bash_profile
+if ! grep -lq  'cd /vagrant' /home/vagrant/.bashrc ; then
+  echo "cd /vagrant" >> /home/vagrant/.bashrc
 fi


### PR DESCRIPTION
....
