### PR TITLE
Increase the example Vagranfile's memory to alleviate crashes.

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     rsync__exclude: '.git/'
 
   config.vm.provider 'virtualbox' do |vb|
-    vb.customize ['modifyvm', :id, '--memory', '512']
+    vb.customize ['modifyvm', :id, '--memory', '2048']
   end
 
   config.vm.provision 'shell', path: 'https://raw.github.com/AgilionApps/VagrantDevEnv/master/scripts/base.sh'


### PR DESCRIPTION
At 512, vagrant shuts down every couple hours :facepunch: 
